### PR TITLE
Set up CI

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,22 @@
+name: Android CI
+
+on:
+  push:
+    branches: [ $default-branch ]
+  pull_request:
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: set up JDK 11
+      uses: actions/setup-java@v2
+      with:
+        java-version: '11'
+        distribution: 'adopt'
+
+    - name: Build with Gradle
+      run: ./gradlew assembleRelease


### PR DESCRIPTION
For now this will simply run the `assembleRelease` task, which will
build only the release variant of the application.